### PR TITLE
fix: Add CSP to allow external images in articles

### DIFF
--- a/hairstyle-blog/generate_article.py
+++ b/hairstyle-blog/generate_article.py
@@ -249,7 +249,8 @@ def generate_html_content(year, month, month_name_kr):
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale-1.0">
+    <meta http-equiv="Content-Security-Policy" content="img-src 'self' https: data:;">
     <title>{year}년 {month_name_kr} 최신트랜드</title>
     <style>
         body {{


### PR DESCRIPTION
Adds a Content Security Policy (CSP) <meta> tag to the generated HTML articles. The policy `img-src 'self' https: data:;` is added to the <head> of the document.

This allows browsers to load images from external HTTPS sources, which was previously being blocked by default security policies (e.g., on GitHub Pages). This prevents the `onerror` attribute on `<img>` tags from being triggered, allowing the images to be displayed as intended.